### PR TITLE
Fix broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
                             getting involved.</p>
                     </div>
                     <div class="card-action">
-                        <a href="get-involved.html">We have open roles, get involved now!</a>
+                        <a href="/pages/get-involved.html">We have open roles, get involved now!</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Was checking out the different parts of the site and the "We have open roles, get involved now!" link was broken on the main `index.html` page. Just needed the `pages` prefix added.  Tested locally and seems to work. 